### PR TITLE
New coffee case #29

### DIFF
--- a/parser.log
+++ b/parser.log
@@ -1,1 +1,1 @@
-[View Lat/Lng in OpenStreetMaps](https://www.openstreetmap.org/?mlat=32.9519876&mlon=-117.2349545#map=19/32.9519876/-117.2349545)
+[View Lat/Lng in OpenStreetMaps](https://www.openstreetmap.org/?mlat=33.25730335&mlon=-116.37980386866096#map=19/33.25730335/-116.37980386866096)

--- a/site/reviews/29.yml
+++ b/site/reviews/29.yml
@@ -1,0 +1,14 @@
+---
+address: 590 Palm Canyon Dr, Borrego Springs, CA 92004
+author: joshuaferrara
+chocolate-score: 3.0
+coffee-score: 4.0
+coffee-to-choco: -0.2
+item: Double Iced Mocha
+latitude: 33.25730335
+longitude: -116.37980386866096
+name: Bighorn Fudge Company
+notes: Didn't try the fudge, but they also serve Julian Pie Co. and amazing ice cream.
+  Also came with a couple of chocolate covered espresso beans too.
+price: 0.0
+whip-cream: Smooth


### PR DESCRIPTION
Author: @joshuaferrara
Closes #29

[View Lat/Lng in OpenStreetMaps](https://www.openstreetmap.org/?mlat=33.25730335&mlon=-116.37980386866096#map=19/33.25730335/-116.37980386866096)

```
**Don't change anything to the left of a `:`**

Coffee Shop: Bighorn Fudge Company
Address: 590 Palm Canyon Dr, Borrego Springs, CA 92004
Drink Name: Double Iced Mocha
Drink Price: 0.00
Coffee-to-Choco Ratio [-0.5, 0.5]: -0.2
Coffee Score [0, 5]: 4
Chocolate Score [0, 5]: 3
Whip Cream (None, Crumbly, or Smooth): Smooth
Notes: Didn't try the fudge, but they also serve Julian Pie Co. and amazing ice cream. Also came with a couple of chocolate covered espresso beans too.
```